### PR TITLE
Fixes #39: Update for the ddev config install instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mkdir ~/Sites/xb-dev
 cd ~/Sites/xb-dev
 
 # Configure the new DDEV project.
-ddev config --project-type=drupal --php-version=8.3 --docroot=web
+ddev config --project-type=drupal10 --docroot=web
 
 # Create the Drupal project.
 ddev composer create drupal/recommended-project:10.x@dev --no-install


### PR DESCRIPTION
Iremoved the php version flag from the ddev config install instructions and changed the project type to drupal 10 for now due to the fact that the composer create instructions target drupal 10 as well. i would recommend to change the ddev config line in the scope of https://github.com/drupal-xb/ddev-drupal-xb-dev/issues/33 to `drupal11`