### PR TITLE
Move repo to `drupal-xb` org

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ddev config --project-type=drupal --php-version=8.3 --docroot=web
 ddev composer create drupal/recommended-project:10.x@dev --no-install
 
 # Install the add-on.
-ddev add-on get TravisCarden/ddev-drupal-xb-dev
+ddev add-on get drupal-xb/ddev-drupal-xb-dev
 
 # Perform one-time setup operations.
 ddev xb-setup

--- a/commands/host/xb-cypress
+++ b/commands/host/xb-cypress
@@ -23,7 +23,7 @@ fi
 # Check if XQuartz is installed and running.
 if ! open -Ra XQuartz; then
   echo "Cannot find XQuartz. Install it and try again."
-  echo "Hint: https://github.com/TravisCarden/ddev-drupal-xb-dev#cypress"
+  echo "Hint: https://github.com/drupal-xb/ddev-drupal-xb-dev#cypress"
   exit 1
 fi
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -64,8 +64,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd "${TESTDIR}" || ( printf "unable to cd to %s\n" "${TESTDIR}" && exit 1 )
-  echo "# ddev add-on get TravisCarden/ddev-drupal-xb-dev with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev add-on get TravisCarden/ddev-drupal-xb-dev
+  echo "# ddev add-on get drupal-xb/ddev-drupal-xb-dev with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get drupal-xb/ddev-drupal-xb-dev
   ddev restart >/dev/null
   health_checks
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,14 +3,14 @@
 # This file is for self-testing this add-on during local development.
 #
 # First, install XQuartz (and ONLY XQuartz) according to the instructions at
-# https://github.com/TravisCarden/ddev-drupal-xb-dev#prerequisites-xquartz
+# https://github.com/drupal-xb/ddev-drupal-xb-dev#prerequisites-xquartz
 # (Stop after configuring XQuartz--do not continue with the steps in the README.
 #
 # Then run the following commands on your host machine to clone the
 # repository fresh and run the script:
 #
 #   cd ~/Projects/temp # This can be anywhere you want.
-#   git clone git@github.com:TravisCarden/ddev-drupal-xb-dev.git
+#   git clone git@github.com:drupal-xb/ddev-drupal-xb-dev.git
 #   cd ddev-drupal-xb-dev
 #   ./tests/test.sh
 


### PR DESCRIPTION
I'm not allocated to this project (right now?), so let's move this from my personal user to an organization so I'm not a bottleneck. The actual transfer is already done, and I've confirmed `ddev add-on get` works with the new namespace. This updates the documentation to correspond.