### PR TITLE
Downgrade PHPStan to 1.x, match Drupal core version of XB's CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd ~/Sites/xb-dev
 ddev config --project-type=drupal11 --docroot=web
 
 # Create the Drupal project.
-ddev composer create drupal/recommended-project:11.x@dev --no-install
+ddev composer create drupal/recommended-project:11.x --no-install
 
 # Install the add-on.
 ddev add-on get drupal-xb/ddev-drupal-xb-dev

--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -62,6 +62,11 @@ ddev composer require \
   --no-interaction \
   drush/drush
 
+# Set the minimum stability to dev, so Experience Builder can be installed.
+# The installation instructions suggest using the non-dev version of
+# `drupal/recommended-project` to match XB's CI.
+ddev composer config minimum-stability dev
+
 # Require the Experience Builder module. Still don't install.
 ddev composer config \
   repositories.xb \
@@ -74,13 +79,24 @@ ddev composer require \
   drupal/experience_builder
 
 # Require dev dependencies. NOW install.
+# We specifically require the 1.x versions of the following packages:
+# - mglaman/phpstan-drupal
+# - phpstan/phpstan
+# - phpstan/phpstan-phpunit
+# XB's codebase does not support PHPStan 2 yet, but drupal-core/dev allows
+# both 1.x and 2.x versions of these packages. This way we can install the 1.x
+# version of `jangregor/phpstan-prophecy`.
 ddev composer require \
   --dev \
   --update-with-all-dependencies \
   --no-interaction \
-  devizzent/cebe-php-openapi:^1.1.4 \
+  drupal/core-dev:~11.1 \
+  devizzent/cebe-php-openapi:^1.0.3 \
   drupal/metatag:^2. \
-  jangregor/phpstan-prophecy:^2.2.0 \
+  mglaman/phpstan-drupal:^1.3.9 \
+  phpstan/phpstan:^1.12.27 \
+  phpstan/phpstan-phpunit:^1.4.2 \
+  jangregor/phpstan-prophecy:^1.0.2 \
   league/openapi-psr7-validator:^0.22.0 \
   webflo/drupal-finder:^1.3.1
 


### PR DESCRIPTION
In #42 the Composer installation errors were solved. What I did not consider was that XB doesn't play well with PHPStan 2 yet. So we need to downgrade to PHPStan 1.x for now.

The challenge was that [`drupal-core/dev` allows both 1.x. and 2.x versions of PHPStan and other packages that depend on PHPStan](https://github.com/drupal/core-dev/blob/11.x/composer.json). So without a `composer.json` file to describe these dependencies, I needed to explicitly install compatible versions.

After that I was still seeing a few PHPStan errors compared to no errors on CI for XB. I tracked that down to be differences in Drupal core. The installation instructions for this add-on included using `drupal/recommended-project:11.x@dev`, but XB [specifies a stable version](https://git.drupalcode.org/project/experience_builder/-/blob/0.x/composer.json?ref_type=heads#L8), which the CI [will respect](https://git.drupalcode.org/project/gitlab_templates/-/blob/main/scripts/expand_composer_json.php?ref_type=heads#L27). I updated the installation instructions accordingly. That meant no more dependency on `drupal-core/dev`, so I added that back in our manual installation.

The result is matching the CI results for `0.x`:

<img width="861" alt="PHPStan results" src="https://github.com/user-attachments/assets/40e0c6fa-f07c-4145-8e5a-7924be78d8af" />
